### PR TITLE
Changing temporary directory to /bot-tmp

### DIFF
--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -33,7 +33,7 @@ elife-bot-repo:
 elife-bot-tmp-link:
     file.symlink:
         - name: /opt/elife-bot/tmp
-        - target: /tmp
+        - target: /bot-tmp
         - require:
             - elife-bot-repo
 
@@ -165,7 +165,7 @@ elife-bot-temporary-files-cleaner:
 
 # WARNING - this can be a little buggy.
 # temporary files accumulate like crazy in production elife-bot
-# on AWS we mount the /tmp dir on a separate EBS volume
+# on AWS we mount the /bot-tmp dir on a separate EBS volume
 
 # dir is a mount point
 #- grep -qs '/var/lib/docker/' /proc/mounts
@@ -185,7 +185,7 @@ format-temp-volume:
 
 mount-temp-volume:
     mount.mounted:
-        - name: /tmp
+        - name: /bot-tmp
         - device: /dev/xvdh
         - fstype: ext4
         - mkmnt: True
@@ -198,10 +198,10 @@ mount-temp-volume:
             - test -b /dev/xvdh
         - unless:
             # mount point already has a volume mounted
-            - cat /proc/mounts | grep --quiet --no-messages /tmp/
+            - cat /proc/mounts | grep --quiet --no-messages /bot-tmp/
 
     cmd.run:
-        - name: chmod -R 777 /tmp
+        - name: chmod -R 777 /bot-tmp
         - require:
             - mount: mount-temp-volume
 


### PR DESCRIPTION
Builder copies files in /tmp to (e.g. `/tmp/highstate.sh`) to execute
them on a target EC2 instance.

However, when a Salt state mounts something over /tmp the process fails
at the end when trying to remove `/tmp/highstate.sh`, as the original
/tmp folder has been shadowed by the new mount.

Therefore, in the arm wrestling between bot and builder, builder gets to
use /tmp.

This change does not affect any production instance, as I would like to
get it in before (re)creating `elife-bot--prod` and porting to it.