### PR TITLE
Running cleanup cron every hour

### DIFF
--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -136,8 +136,8 @@ elife-bot-temporary-files-cleaner:
     cron.present:
         - identifier: temp-files-cleaner
         - name: python /opt/rmrf_enter/elife-bot.py > /dev/null
-        - minute: 0
-        - hour: 2
+        - minute: random
+        - hour: *
         - require:
             - file: elife-bot-temporary-files-cleaner
 


### PR DESCRIPTION
This should not interfere with running workflows as it only acts on files older than 2 days.

When instances are turned on, they stay up for at least an hour, so this should suffice to clean up their /bot-tmp folder before they are shutdown again. Only executing it at 2 AM sometimes lead to the cleanup not being executed for several days until the disk fills up.