### PR TITLE
Use git+https for elife-poa-xml-generation

### DIFF
--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -69,11 +69,10 @@ elife-bot-crossref-cfg:
 
 elife-poa-xml-generation-repo:
     git.latest:
-        - name: git@github.com:elifesciences/elife-poa-xml-generation.git
+        - name: https://github.com/elifesciences/elife-poa-xml-generation
         - rev: master
         - branch: master
         - target: /opt/elife-poa-xml-generation
-        - identity: {{ pillar.elife.projects_builder.key or '' }}
         - force_fetch: True
         - force_checkout: True
         - force_reset: True


### PR DESCRIPTION
This is a case similar to bot-lax-adaptor: a sidecar application that sometimes need to be switched to a particular commit/branch by an automated process.

To ease the switch to a new commit, we can use the `https` scheme rather than `ssh`. The latter would require to create an SSH key for the `elife-bot--*` EC2 instances.

/cc @gnott I don't expect this to impact anyone's work, but you never know