### PR TITLE
switched to java8 for sejda

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -2,7 +2,7 @@ base:
     '*':
         - elife
         - elife.mercurial
-        - elife.java # strip-coverletter requirement
+        - elife.java8 # strip-coverletter requirement
         - elife.redis-server
         - elife-bot
         - elife-bot.feeder


### PR DESCRIPTION
turns out sejda, the replacement for pdfsam, requires java 1.8 and not the 1.7 installed.

a few reasons this passed tests:
* changes for strip-coverletter hadn't been merged in
* strip-coverletter had only been tested locally and within a new docker container
* no smoke test for strip-coverletter in elife-bot-formula

@giorgiosironi , @gnott , [I've reverted the merge in strip-coverletter](https://github.com/elifesciences/strip-coverletter/commit/e1ae5f3f096a662defed263bf6b258de3f422c6c) while the elife-bot machine has java8 installed and I add a smoke test to the elife-bot-formula to ensure it's happy

builder-private PR: https://github.com/elifesciences/builder-private/pull/93