### PR TITLE
makes the permissions on the writable docker dir more lenient

### DIFF
--- a/salt/elife-bot/strip-coverletter.sls
+++ b/salt/elife-bot/strip-coverletter.sls
@@ -44,6 +44,19 @@ strip-coverletter-working:
 # dockerised version
 #
 
+strip-coverletter-docker-writable-dir:
+    file.directory:
+        - name: /opt/strip-coverletter/vol
+        - user: root
+        - group: {{ pillar.elife.deploy_user.username }}
+        - dir_mode: 777 # TODO: permissions problem here. what user is this script run as?
+        - recurse: # shouldn't be necessary, dir is cleared out after each call
+            - user
+            - group
+            - mode
+        - require:
+            - install-strip-coverletter
+
 strip-coverletter-docker-image:
     cmd.run:
         - cwd: /opt/strip-coverletter
@@ -51,9 +64,11 @@ strip-coverletter-docker-image:
         - require:
             - docker-ready
 
+# TODO: this would be a better test if it were run as the user calling strip-coverletter
 strip-coverletter-docker-working:
     cmd.run:
         - cwd: /opt/strip-coverletter
         - name: ./strip-coverletter-docker.sh /opt/strip-coverletter/dummy.pdf tmp.pdf && rm tmp.pdf
         - require:
             - strip-coverletter-docker-image
+            - strip-coverletter-docker-writable-dir

--- a/salt/elife-bot/strip-coverletter.sls
+++ b/salt/elife-bot/strip-coverletter.sls
@@ -68,7 +68,7 @@ strip-coverletter-docker-working:
     cmd.run:
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /opt/strip-coverletter
-        - name: ./strip-coverletter-docker.sh /opt/strip-coverletter/dummy.pdf tmp.pdf && rm tmp.pdf
+        - name: ./strip-coverletter-docker.sh /opt/strip-coverletter/dummy.pdf /tmp/dummy.pdf && rm /tmp/dummy.pdf
         - require:
             - strip-coverletter-docker-image
             - strip-coverletter-docker-writable-dir

--- a/salt/elife-bot/strip-coverletter.sls
+++ b/salt/elife-bot/strip-coverletter.sls
@@ -47,9 +47,9 @@ strip-coverletter-working:
 strip-coverletter-docker-writable-dir:
     file.directory:
         - name: /opt/strip-coverletter/vol
-        - user: root
+        - user: {{ pillar.elife.deploy_user.username }}
         - group: {{ pillar.elife.deploy_user.username }}
-        - dir_mode: 777 # TODO: permissions problem here. what user is this script run as?
+        - dir_mode: 774 # rwxrwxr--
         - recurse: # shouldn't be necessary, dir is cleared out after each call
             - user
             - group
@@ -64,9 +64,9 @@ strip-coverletter-docker-image:
         - require:
             - docker-ready
 
-# TODO: this would be a better test if it were run as the user calling strip-coverletter
 strip-coverletter-docker-working:
     cmd.run:
+        - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /opt/strip-coverletter
         - name: ./strip-coverletter-docker.sh /opt/strip-coverletter/dummy.pdf tmp.pdf && rm tmp.pdf
         - require:


### PR DESCRIPTION
@giorgiosironi , what have you found to be the best way to handle permissions when bridging fs and container? 

in the strip-coverletter script the `--user` parameter is passed in with the id of the user currently running the script, but this will need to match the permissions of the `vol/` directory, which this PR sets to `root:elife` and `777`.

the test had been merrily running as the `root` user and had always been passing 