### PR TITLE
Bot, crossref.cfg file updated.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -1,6 +1,9 @@
 [DEFAULT]
 crossref_schema_version: 4.4.0
 generator: elife-crossref-xml-generation
+registrant: 
+depositor_name: 
+email_address: 
 contrib_types: ["author", "on-behalf-of"]
 jats_abstract: false
 face_markup: false
@@ -8,14 +11,14 @@ crossmark: true
 crossmark_policy:
 crossmark_domain:
 batch_file_prefix: crossref-
-doi_pattern: {doi}
-component_doi_pattern: {doi}
+doi_pattern: 
+component_doi_pattern: 
 component_license_ref:
 elife_style_component_doi: false
 archive_locations: ["CLOCKSS"]
 elocation_id: true
-access_indicators_applies_to: ["vor", "am", "tdm"]
-pub_date_types: ["pub", "publication", "epub"]
+access_indicators_applies_to: ["vor"]
+pub_date_types: ["pub", "publication", "epub", "epub-ppub"]
 reference_distribution_opts:
 text_mining_xml_pattern: 
 text_mining_pdf_pattern:
@@ -31,7 +34,8 @@ component_doi_pattern: https://elifesciences.org/articles/{manuscript}{prefix1}#
 component_license_ref: https://submit.elifesciences.org/html/elife_author_instructions.html#policies
 elife_style_component_doi: true
 year_of_first_volume: 2012
-elocation_id: false
+elocation_id: true
+access_indicators_applies_to: ["vor", "am", "tdm"]
 reference_distribution_opts: any
 text_mining_xml_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.xml
 text_mining_pdf_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.pdf


### PR DESCRIPTION
To include ``elocation_id`` in Crossref deposits for eLife articles, this config file will make it happen, only to be merged after this ``elife-bot`` PR though https://github.com/elifesciences/elife-bot/pull/694, because this config file is compatible with the latest release of ``elife-crossref-xml-generation``.