### PR TITLE
In PoA library settings, add datasets to the overflow CSV file list.

### DIFF
--- a/salt/elife-bot/config/opt-elife-poa-xml-generation-settings.py
+++ b/salt/elife-bot/config/opt-elife-poa-xml-generation-settings.py
@@ -24,7 +24,7 @@ XLS_FILES = 	{"authors" : "poa_author.csv",
                  }
 
 # Special files that allow quotation marks in their final column: column 3
-OVERFLOW_XLS_FILES = ["abstract", "title", "ethics"]
+OVERFLOW_XLS_FILES = ["abstract", "title", "ethics", "datasets"]
 
 XLS_COLUMN_HEADINGS = {"author_position" : "poa_a_seq",
 					"subject_areas" : "poa_s_subjectarea",


### PR DESCRIPTION
Related to PR https://github.com/elifesciences/elife-poa-xml-generation/pull/331, this PR here should not be merged before the library PR is merged and deployed, otherwise the datasets file is not ready to be supported for overflow parsing.