### PR TITLE
Add abstract_label_types property to the pubmed cfg file.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-pubmed.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-pubmed.cfg
@@ -14,9 +14,12 @@ group_author_contrib_types: ["author non-byline", "on-behalf-of"]
 history_date_types: ["received", "accepted"]
 split_article_categories: False
 publication_types: publication_types.yaml
+# abstract paragraphs starting with these terms turn into an AbstractText label value
+abstract_label_types: []
 
 [elife]
 year_of_first_volume: 2012
 batch_file_prefix: elife-pubmed-
 build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'is_poa', 'keywords', 'license', 'pub_dates', 'related_articles', 'research_organisms', 'volume']
 split_article_categories: True
+abstract_label_types: ["Editorial note:"]


### PR DESCRIPTION
Adds support for the logic in the PR for the library https://github.com/elifesciences/elife-pubmed-xml-generation/pull/25  Will allow ``"Editorial note:"`` paragraphs in eLife articles to get a special label in the PubMed deposits. All other PubMed deposits will use the ``<AbstractText>`` tag when the updated library is deployed.