### PR TITLE
Only execute SWF calls on AWS

### DIFF
--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -227,10 +227,10 @@ app-done:
 
 register-swf:
     cmd.run:
-        {% if stack_name != 'elife-bot--silent-corrections' %}
+        {% if salt['elife.only_on_aws']() %}
         - name: venv/bin/python register.py -e {{ pillar.elife.env }}
         {% else %}
-        - name: echo "register.py should not run on this old branch"
+        - name: echo "register.py cannot run locally as it requires AWS credentials"
         {% endif %}
         - user: {{ pillar.elife.deploy_user.username }}
         - cwd: /opt/elife-bot


### PR DESCRIPTION
The SWF stuff failed in Vagrant due to lack of credentials.

I also have another problem with `strip-coverletter` failing to write to a volume because its user is `worker`, want to see if it reproduces.