### PR TITLE
Add the digest.cfg config file.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-digest.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-digest.cfg
@@ -1,0 +1,22 @@
+[DEFAULT]
+medium_title_pattern: <h1>{digest_title}</h1>
+medium_summary_pattern: <h2>{digest_summary}</h2>
+medium_paragraph_pattern: <p>{text}</p>
+medium_image_url: {file_name}
+medium_figcaption_pattern: <figcaption>{caption}{credit}{license}</figcaption>
+medium_figure_pattern: <figure><img src="{image_url}" />{figcaption}</figure>
+medium_footer_pattern: 
+medium_content_pattern: {figure}{title}{summary}<hr/>{body}{footer}
+medium_content_format: html
+medium_license: 
+# Medium application settings
+medium_application_client_id:
+medium_application_client_secret:
+# Medium user settings
+medium_access_token:
+# DOCX output
+output_file_name_pattern: {author}_{msid:0>5}.docx
+
+[elife]
+medium_license: cc-40-by
+medium_image_url: https://iiif.elifesciences.org/digests:{msid:0>5}%2F{file_name}/full/full/0/default.jpg

--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -97,6 +97,14 @@ elife-bot-packagepoa-cfg:
         - require:
             - elife-bot-repo
 
+elife-bot-digest-cfg:
+    file.managed:
+        - user: {{ pillar.elife.deploy_user.username }}
+        - name: /opt/elife-bot/digest.cfg
+        - source: salt://elife-bot/config/opt-elife-bot-digest.cfg
+        - require:
+            - elife-bot-repo
+
 #
 #
 #


### PR DESCRIPTION
The ``digest.cfg`` file taken from the https://github.com/elifesciences/digest-parser library, making it available for the bot to load in activities.

It wasn't needed just yet except I moved the ``.docx`` output file naming logic into the library, and it is possible to specify the naming pattern in the ``.cfg`` file. Once the config file is available, I can change ``EmailDigest`` to be able to load the pattern from the config file (if available) rather than relying on the default naming pattern that is hard-coded in the library itself.

The contents of the config file will change in the future, especially when the footer content of the Medium post is specified here, although that may be some time in the future.