### PR TITLE
In digest.cfg, the image will no longer have a credit or license …

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-digest.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-digest.cfg
@@ -3,7 +3,7 @@ medium_title_pattern: <h1>{digest_title}</h1>
 medium_summary_pattern: <h2>{digest_summary}</h2>
 medium_paragraph_pattern: <p>{text}</p>
 medium_image_url: {file_name}
-medium_figcaption_pattern: <figcaption>{caption}{credit}{license}</figcaption>
+medium_figcaption_pattern: <figcaption>{caption}</figcaption>
 medium_figure_pattern: <figure><img src="{image_url}" />{figcaption}</figure>
 medium_footer_pattern: 
 medium_content_pattern: {figure}{title}{summary}<hr/>{body}{footer}


### PR DESCRIPTION
…property for the Medium figcaption.

Related to ``digest-parser`` changes in PR https://github.com/elifesciences/digest-parser/pull/47. The image  will only have a caption.

This ``digest.cfg`` change is not a rush, but we'll want it by the time we start to test creating draft Medium posts.