### PR TITLE
elife medium_footer_pattern for the digest.cfg file and journal.url

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-digest.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-digest.cfg
@@ -26,7 +26,7 @@ iiif_info_url:
 [elife]
 medium_license: cc-40-by
 medium_image_url: {{ pillar.elife_bot.iiif.url }}digests/{msid:0>5}%2F{file_name}/full/full/0/default.jpg
-medium_footer_pattern: <hr/><p><em>Originally published at <a href="{{ pillar.elife_bot.journal.url }}/digests/{msid:0>5}">{{ pillar.elife_bot.journal.url }}/digests/{msid:0>5}</a>.</em></p>
+medium_footer_pattern: <hr/><p><em>Originally published at <a href="https://elifesciences.org/digests/{msid:0>5}">https://elifesciences.org/digests/{msid:0>5}</a>.</em></p>
 doi_pattern: https://doi.org/10.7554/eLife.{msid:0>5}
 iiif_image_uri: {{ pillar.elife_bot.iiif.url }}digests/{msid:0>5}%2F{file_name}
 iiif_image_source_uri: {{ pillar.elife_bot.iiif.url }}digests/{msid:0>5}%2F{file_name}/full/full/0/default.jpg

--- a/salt/elife-bot/config/opt-elife-bot-digest.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-digest.cfg
@@ -26,6 +26,7 @@ iiif_info_url:
 [elife]
 medium_license: cc-40-by
 medium_image_url: {{ pillar.elife_bot.iiif.url }}digests/{msid:0>5}%2F{file_name}/full/full/0/default.jpg
+medium_footer_pattern: <hr/><p><em>Originally published at <a href="{{ pillar.elife_bot.journal.url }}/digests/{msid:0>5}">{{ pillar.elife_bot.journal.url }}/digests/{msid:0>5}</a>.</em></p>
 doi_pattern: https://doi.org/10.7554/eLife.{msid:0>5}
 iiif_image_uri: {{ pillar.elife_bot.iiif.url }}digests/{msid:0>5}%2F{file_name}
 iiif_image_source_uri: {{ pillar.elife_bot.iiif.url }}digests/{msid:0>5}%2F{file_name}/full/full/0/default.jpg

--- a/salt/pillar/elife-bot.sls
+++ b/salt/pillar/elife-bot.sls
@@ -7,6 +7,8 @@ elife_bot:
         application_client_id: 1234s5b67am890p31l722ee3fe1fd874f171953214406731afddb1754e67655cd
         application_client_secret: a1234567b8cd
         access_token: a9b4587c723de18fghi1jk56lmno5pq18rst5uv9
+    journal:
+        url = 'https://elifesciences.org'
 
 elife:
     # for testing

--- a/salt/pillar/elife-bot.sls
+++ b/salt/pillar/elife-bot.sls
@@ -7,8 +7,6 @@ elife_bot:
         application_client_id: 1234s5b67am890p31l722ee3fe1fd874f171953214406731afddb1754e67655cd
         application_client_secret: a1234567b8cd
         access_token: a9b4587c723de18fghi1jk56lmno5pq18rst5uv9
-    journal:
-        url = 'https://elifesciences.org'
 
 elife:
     # for testing


### PR DESCRIPTION
Cannot be merged before https://github.com/elifesciences/digest-parser/pull/62 is and the `digest-parser` library is updated in the `elife-bot` project.

I looked for an existing place to get `https://elifesciences.org` from the existing formula values, but in the end I added it as a new section under the `elife_bot` area. Maybe that is good separation from other projects, or maybe there is some base environment value it should use instead?