### PR TITLE
Feature: restarts the processes when bot settings change

### DIFF
--- a/salt/elife-bot/processes.sls
+++ b/salt/elife-bot/processes.sls
@@ -33,6 +33,7 @@ elife-bot-processes-start:
             - elife-bot-processes-task
         - watch:
             - elife-bot-repo
+            - elife-bot-settings
         - listen:
             - newrelic-ini-configuration-appname
             - newrelic-ini-configuration-logfile


### PR DESCRIPTION
@gnott , this is related to the credentials rotation that is happening at the moment. The machine user for elife-bot is using both sets of credentials right now. This typically happens when a process needs to be restarted to re-read the new settings. In elife-bot's case, it's holding on to some SQS settings.

In this PR I *think* this is the process that needs restarting but not 100% certain.