### PR TITLE
Add component_exclude_types to crossref.cfg

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -14,6 +14,7 @@ batch_file_prefix: crossref-
 doi_pattern: 
 component_doi_pattern: 
 component_license_ref:
+component_exclude_types: []
 elife_style_component_doi: false
 archive_locations: ["CLOCKSS"]
 elocation_id: true
@@ -32,6 +33,7 @@ batch_file_prefix: elife-crossref-
 doi_pattern: https://elifesciences.org/articles/{manuscript}
 component_doi_pattern: https://elifesciences.org/articles/{manuscript}{prefix1}#{id}
 component_license_ref: https://submit.elifesciences.org/html/elife_author_instructions.html#policies
+component_exclude_types: ["sub-article"]
 elife_style_component_doi: true
 year_of_first_volume: 2012
 elocation_id: true


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-crossref-feed/issues/141

When this `crossref.cfg` config file change it merged and deployed, then we will no longer include decision letter or author response component DOIs in Crossref deposits.

As of today, I'm waiting for clarification from Melissa for when this should be deployed.