### PR TITLE
peer_review_doi_pattern for Crossref config.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -13,6 +13,7 @@ crossmark_domain:
 batch_file_prefix: crossref-
 doi_pattern: 
 component_doi_pattern: 
+peer_review_doi_pattern: 
 component_license_ref:
 elife_style_component_doi: false
 archive_locations: ["CLOCKSS"]
@@ -31,6 +32,7 @@ crossmark: false
 batch_file_prefix: elife-crossref-
 doi_pattern: https://elifesciences.org/articles/{manuscript}
 component_doi_pattern: https://elifesciences.org/articles/{manuscript}{prefix1}#{id}
+peer_review_doi_pattern: https://elifesciences.org/articles/{manuscript}{prefix1}#{id}
 component_license_ref: https://submit.elifesciences.org/html/elife_author_instructions.html#policies
 elife_style_component_doi: true
 year_of_first_volume: 2012


### PR DESCRIPTION
Crossref peer review deposit logic I am working on today, I created this new configuration file value for generating the URL a DOI will forward to.

The pattern for peer reviews is currently the same as the one for components, which make sense for eLife because they are components (currently). Establishing a separate DOI pattern in the configuration makes it easier for me to build, we could potentially change the URL path to view peer reviews, or other users of the library could have their peer reviews in a different place than the article or article components.

This PR should be backwards compatible and can be merged any time.

I don't think it will cause a merge conflict with draft PR https://github.com/elifesciences/elife-bot-formula/pull/44, but if this one is merged first we can check afterward.