### PR TITLE
Config file letterparser.cfg

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
@@ -1,8 +1,12 @@
 [DEFAULT]
 doi_pattern:
 preamble: 
-docker_image: knsit/pandoc:v2.5
+docker_image: pandoc/core:2.6
+fig_filename_pattern: journalname-{manuscript:0>5}-{id_value}-fig{num}
+video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
 
 [elife]
-doi_pattern: 10.7554/eLife.{manuscript}.{id}
+doi_pattern: 10.7554/eLife.{manuscript:0>5}.{id}
 preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
+fig_filename_pattern: elife-{manuscript:0>5}-{id_value}-fig{num}
+video_filename_pattern: elife-{manuscript:0>5}-{id_value}-video{num}

--- a/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
@@ -1,0 +1,8 @@
+[DEFAULT]
+doi_pattern:
+preamble: 
+docker_image: knsit/pandoc:v2.5
+
+[elife]
+doi_pattern: 10.7554/eLife.{manuscript}.{id}
+preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>

--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -110,6 +110,15 @@ elife-bot-digest-cfg:
         - require:
             - elife-bot-repo
 
+elife-bot-letterparser-cfg:
+    file.managed:
+        - user: {{ pillar.elife.deploy_user.username }}
+        - name: /opt/elife-bot/letterparser.cfg
+        - source: salt://elife-bot/config/opt-elife-bot-letterparser.cfg
+        - template: jinja
+        - require:
+            - elife-bot-repo
+
 #
 # clean up the temporary files that accumulate
 #


### PR DESCRIPTION
Related to issue https://github.com/elifesciences/decision-letter-parser/issues/43

I created a config file named `letterparser.cfg` that will be used by the decision letter parser library in an `elife-bot` workflow in the future. I'm adding the file to this formula now before I forget.

- [x] Update `letterparser.cfg` to latest before merging