### PR TITLE
Provision GCP credentials from pillar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-elifeFormula('elife-bot', '/opt/elife-bot', null, ['s1604'])
+elifeFormula('elife-bot', '/opt/elife-bot')

--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -204,6 +204,19 @@ register-swf:
         - require:
             - cmd: app-done
 
+elife-bot-gcp-credentials:
+    file.managed:
+        - name: /etc/gcp-credentials.json
+        - contents: {{ pillar.elife_bot.gcp.credentials_json }}
+
+elife-bot-gcp-credentials-environment-variables:
+    file.managed:
+        - name: /etc/profile.d/elife-bot-gcp-credentials.sh
+        - contents: |
+            export GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp-credentials.json
+        - require:
+            - elife-bot-gcp-credentials
+
 {% if salt['grains.get']('osrelease') == '14.04' %}
 {% set processes = ['decider', 'worker', 'queue_worker', 'queue_workflow_starter', 'shimmy', 'lax_response_adapter'] %}
 {% for process in processes %}

--- a/salt/pillar/elife-bot.sls
+++ b/salt/pillar/elife-bot.sls
@@ -7,6 +7,9 @@ elife_bot:
         application_client_id: 1234s5b67am890p31l722ee3fe1fd874f171953214406731afddb1754e67655cd
         application_client_secret: a1234567b8cd
         access_token: a9b4587c723de18fghi1jk56lmno5pq18rst5uv9
+    gcp:
+        credentials_json: '{}'
+
 
 elife:
     # for testing


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/5178

May depend on https://github.com/elifesciences/builder-configuration/pull/93 but maybe it will get the `ci` value from Vault.