### PR TITLE
Create standard /ext as a symlink

### DIFF
--- a/salt/elife-bot/external-volume.sls
+++ b/salt/elife-bot/external-volume.sls
@@ -1,0 +1,48 @@
+# WARNING - this can be a little buggy.
+# temporary files accumulate like crazy in production elife-bot
+# on AWS we mount the /bot-tmp dir on a separate EBS volume
+
+# dir is a mount point
+#- grep -qs '/var/lib/docker/' /proc/mounts
+
+# volume to mount exists and is block special (-b)
+#- test -b /dev/xvdh
+
+format-temp-volume:
+    cmd.run: 
+        - name: mkfs -t ext4 /dev/xvdh
+        - onlyif:
+            # disk exists
+            - test -b /dev/xvdh
+        - unless:
+            # volume exists and is already formatted
+            - file --special-files /dev/xvdh | grep ext4
+
+mount-temp-volume:
+    mount.mounted:
+        - name: /bot-tmp
+        - device: /dev/xvdh
+        - fstype: ext4
+        - mkmnt: True
+        - opts:
+            - defaults
+        - require:
+            - cmd: format-temp-volume
+        - onlyif:
+            # disk exists
+            - test -b /dev/xvdh
+        - unless:
+            # mount point already has a volume mounted
+            - cat /proc/mounts | grep --quiet --no-messages /bot-tmp/
+
+    cmd.run:
+        - name: mkdir -p /bot-tmp && chmod -R 777 /bot-tmp
+        - require:
+            - mount: mount-temp-volume
+
+    file.symlink:
+        - name: /ext
+        - target: /bot-tmp
+        - require:
+            - cmd: mount-temp-volume
+

--- a/salt/elife-bot/external-volume.sls
+++ b/salt/elife-bot/external-volume.sls
@@ -52,7 +52,7 @@ mount-temp-volume-linked-to-ext:
             # if it's not a link
             # (meaning it is a directory, and
             # not a link to a directory)
-            if [[ ! -L /ext; ]] then
+            if [[ ! -L /ext ]]; then
                 mv /ext/docker /bot-tmp/docker
                 ln -s /bot-tmp/docker /ext/docker
             fi

--- a/salt/elife-bot/external-volume.sls
+++ b/salt/elife-bot/external-volume.sls
@@ -40,9 +40,31 @@ mount-temp-volume:
         - require:
             - mount: mount-temp-volume
 
+mount-temp-volume-linked-to-ext:
+    # TODO: temporary for the switch, remove after porting
+    # all elife-bot instances
+    cmd.run:
+        - name: |
+            set -e
+            if systemctl status docker; then
+                systemctl stop docker
+            fi
+            # if it's not a link
+            # (meaning it is a directory, and
+            # not a link to a directory)
+            if [[ ! -L /ext; ]] then
+                mv /ext/docker /bot-tmp/docker
+                ln -s /bot-tmp/docker /ext/docker
+            fi
+            # best effort, docker may not be available
+            # or already running
+            systemctl start docker || true
+        - require:
+            - cmd: mount-temp-volume
+
     file.symlink:
         - name: /ext
         - target: /bot-tmp
         - require:
-            - cmd: mount-temp-volume
+            - cmd: mount-temp-volume-linked-to-ext
 

--- a/salt/elife-bot/external-volume.sls
+++ b/salt/elife-bot/external-volume.sls
@@ -49,6 +49,10 @@ mount-temp-volume-linked-to-ext:
             if [[ -d /ext/docker ]]; then
                 if systemctl status docker; then
                     echo "docker daemon is running"
+                    docker stop $(docker ps -q)
+                    echo "docker containers stopped"
+                    docker container prune
+                    echo "docker containers removed"
                     systemctl stop docker
                     echo "docker daemon stopped"
                 fi

--- a/salt/elife-bot/external-volume.sls
+++ b/salt/elife-bot/external-volume.sls
@@ -50,7 +50,7 @@ mount-temp-volume-linked-to-ext:
                 if systemctl status docker; then
                     echo "docker daemon is running"
                     systemctl stop docker
-                    echo "docker deamon stopped"
+                    echo "docker daemon stopped"
                 fi
                 # if it's not a link
                 # (meaning it is a directory, and
@@ -58,6 +58,8 @@ mount-temp-volume-linked-to-ext:
                 if [[ ! -L /ext ]]; then
                     echo "/ext contents need to be moved"
                     mv /ext/docker /bot-tmp/docker
+                    echo "removing empty /ext"
+                    rmdir /ext
                     echo "symlinking /ext to new destination"
                     ln -sf /bot-tmp /ext
                 fi

--- a/salt/elife-bot/external-volume.sls
+++ b/salt/elife-bot/external-volume.sls
@@ -48,17 +48,22 @@ mount-temp-volume-linked-to-ext:
             set -e
             if [[ -d /ext/docker ]]; then
                 if systemctl status docker; then
+                    echo "docker daemon is running"
                     systemctl stop docker
+                    echo "docker deamon stopped"
                 fi
                 # if it's not a link
                 # (meaning it is a directory, and
                 # not a link to a directory)
                 if [[ ! -L /ext ]]; then
+                    echo "/ext contents need to be moved"
                     mv /ext/docker /bot-tmp/docker
+                    echo "symlinking /ext to new destination"
                     ln -sf /bot-tmp /ext
                 fi
                 # best effort, docker may not be available
                 # or already running
+                echo "forcing docker daemon to start"
                 systemctl start docker || true
             fi
         - require:

--- a/salt/elife-bot/external-volume.sls
+++ b/salt/elife-bot/external-volume.sls
@@ -46,19 +46,21 @@ mount-temp-volume-linked-to-ext:
     cmd.run:
         - name: |
             set -e
-            if systemctl status docker; then
-                systemctl stop docker
+            if [[ -d /ext/docker ]]; then
+                if systemctl status docker; then
+                    systemctl stop docker
+                fi
+                # if it's not a link
+                # (meaning it is a directory, and
+                # not a link to a directory)
+                if [[ ! -L /ext ]]; then
+                    mv /ext/docker /bot-tmp/docker
+                    ln -sf /bot-tmp /ext
+                fi
+                # best effort, docker may not be available
+                # or already running
+                systemctl start docker || true
             fi
-            # if it's not a link
-            # (meaning it is a directory, and
-            # not a link to a directory)
-            if [[ ! -L /ext ]]; then
-                mv /ext/docker /bot-tmp/docker
-                ln -s /bot-tmp/docker /ext/docker
-            fi
-            # best effort, docker may not be available
-            # or already running
-            systemctl start docker || true
         - require:
             - cmd: mount-temp-volume
 

--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -168,6 +168,13 @@ mount-temp-volume:
         - require:
             - mount: mount-temp-volume
 
+    file.symlink:
+        - name: /ext
+        - target: /bot-tmp
+        - require:
+            - cmd: mount-temp-volume
+
+
 elife-bot-log-files:
     cmd.run:
         - name: chown -f {{ pillar.elife.deploy_user.username }}:{{ pillar.elife.deploy_user.username }} *.log || true
@@ -187,7 +194,7 @@ app-done:
             - service: redis-server
             - file: elife-bot-tmp-link
             - elife-bot-virtualenv
-            - cmd: mount-temp-volume
+            - mount-temp-volume
             - cmd: elife-bot-log-files
 
 {% set stack_name = salt['elife.cfg']('cfn.stack_name') %}

--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -126,54 +126,6 @@ elife-bot-temporary-files-cleaner:
         - hour: '*'
 
 
-# WARNING - this can be a little buggy.
-# temporary files accumulate like crazy in production elife-bot
-# on AWS we mount the /bot-tmp dir on a separate EBS volume
-
-# dir is a mount point
-#- grep -qs '/var/lib/docker/' /proc/mounts
-
-# volume to mount exists and is block special (-b)
-#- test -b /dev/xvdh
-
-format-temp-volume:
-    cmd.run: 
-        - name: mkfs -t ext4 /dev/xvdh
-        - onlyif:
-            # disk exists
-            - test -b /dev/xvdh
-        - unless:
-            # volume exists and is already formatted
-            - file --special-files /dev/xvdh | grep ext4
-
-mount-temp-volume:
-    mount.mounted:
-        - name: /bot-tmp
-        - device: /dev/xvdh
-        - fstype: ext4
-        - mkmnt: True
-        - opts:
-            - defaults
-        - require:
-            - cmd: format-temp-volume
-        - onlyif:
-            # disk exists
-            - test -b /dev/xvdh
-        - unless:
-            # mount point already has a volume mounted
-            - cat /proc/mounts | grep --quiet --no-messages /bot-tmp/
-
-    cmd.run:
-        - name: mkdir -p /bot-tmp && chmod -R 777 /bot-tmp
-        - require:
-            - mount: mount-temp-volume
-
-    file.symlink:
-        - name: /ext
-        - target: /bot-tmp
-        - require:
-            - cmd: mount-temp-volume
-
 
 elife-bot-log-files:
     cmd.run:

--- a/salt/example.top
+++ b/salt/example.top
@@ -2,6 +2,7 @@ base:
     '*':
         - elife
         - elife.redis-server
+        - elife-bot.external-volume
         - elife.docker
         - elife-bot.strip-coverletter
         - elife-bot


### PR DESCRIPTION
For https://github.com/elifesciences/elife-bot/pull/973 and related issue https://github.com/elifesciences/issues/issues/5208

This allows our Docker setup to eventually use it for `/var/lib/docker`
and for large images to be pulled and run.