### PR TITLE
Fix: adds GCP envvar to service worker template

### DIFF
--- a/salt/elife-bot/templates/lib-systemd-system-botprocess@.service
+++ b/salt/elife-bot/templates/lib-systemd-system-botprocess@.service
@@ -19,8 +19,9 @@ TimeoutStopSec=300
 User={{ pillar.elife.deploy_user.username }}
 WorkingDirectory=/opt/elife-bot
 {% if pillar.elife.newrelic.enabled %}
-Environment="NEW_RELIC_CONFIG_FILE=/opt/elife-bot/newrelic.ini"
+Environment="NEW_RELIC_CONFIG_FILE=/opt/elife-bot/newrelic.ini" "GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp-credentials.json"
 ExecStart=/opt/elife-bot/venv/bin/newrelic-admin run-program /opt/elife-bot/venv/bin/python {{ process }}.py -e {{ pillar.elife.env }} %i
 {% else %}
+Environment="GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp-credentials.json"
 ExecStart=/opt/elife-bot/venv/bin/python {{ process }}.py -e {{ pillar.elife.env }} %i
 {% endif %}


### PR DESCRIPTION
* adds GOOGLE_APPLICATION_CREDENTIALS envvar to service workers

cc @gnott 