### PR TITLE
Update docker image used for pandoc.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
@@ -1,12 +1,13 @@
 [DEFAULT]
 doi_pattern:
 preamble: 
-docker_image: pandoc/core:2.6
+docker_image: pandoc/core:2.7
 fig_filename_pattern: journalname-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
 
 [elife]
 doi_pattern: 10.7554/eLife.{manuscript:0>5}.{id}
 preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
+docker_image: elifesciences/pandoc:2.7
 fig_filename_pattern: elife-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: elife-{manuscript:0>5}-{id_value}-video{num}


### PR DESCRIPTION
Remaining step to issue https://github.com/elifesciences/issues/issues/5233 which is in my hands to complete.

This, in theory, is how the config can work: there is a default pandoc 2.7 docker image (as specified in the Python library) in the `DEFAULT` section, but in the `elife` section of the config file, we use the docker image tag from the `elifesciences` Docker hub account.

This config file is yet to be loaded and used in the `elife-bot` project, but I intend to be working on that in the next few days. I may merge this myself if I am blocked, otherwise it is open to comments.