### PR TITLE
Some cfg file values for settings.py

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -88,6 +88,16 @@ class dev():
     article_subjects_data_bucket = "bot/article_subjects_data"
     article_subjects_data_file = "article_subjects.csv"
  
+    # smtp IAM user
+    smtp_host = ''
+    smtp_port = 465
+    smtp_username = ''
+    # this is *not* an AWS *secret access key*, but an SMTP password!
+    # use builder-private/scripts/smtp_password.sh to regenerate
+    smtp_password = ''
+    smtp_starttls = False
+    smtp_ssl = True
+
     # POA email settings
     ses_poa_sender_email = ""
     ses_poa_recipient_email = ""

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -239,7 +239,8 @@ class dev():
     setLevel = "INFO"
     
     # Session
-    session_class = "RedisSession"
+    session_class = "S3Session"
+    s3_session_bucket = "prod-sessions"
 
     # Redis
     redis_host = "127.0.0.1"

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -69,11 +69,6 @@ class dev():
     ses_sender_email = ""
     ses_admin_email = []
 
-    # CDN bucket settings
-    cdn_bucket = 'cdn'
-    cdn_distribution_id = ''
-    cdn_domain_name = '.cloudfront.net'
-
     # Lens bucket settings
     lens_bucket = 'lens'
     lens_distribution_id = ''

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -248,6 +248,33 @@ class dev():
     redis_db = 0
     redis_expire_key = 86400
 
+    github_token = ""
+    git_repo_name = "article-xml"
+    git_repo_path = "/articles/"
+
+    # eLife 2.0 bot lax communication settings
+    xml_info_queue = "inc"
+    lax_response_queue = "out" 
+    video_url = "https://video-metadata.example.org/"
+
+    pdf_cover_generator = "http://personalised-covers.example.org/personalised-covers/"
+    # temporary
+    pdf_cover_landing_page = "http://personalised-covers.example.org/personalcover/options"
+
+    # IIIF
+    path_to_iiif_server = "https://iiif.example.org/lax/"
+    iiif_resolver = "{article_id}%2F{article_fig}/full/full/0/default.jpg"
+
+    # Fastly CDNs
+    fastly_service_ids = ['', '']
+    fastly_api_key = ''
+
+    article_path_pattern = "/articles/{id}v{version}"
+
+    # BigQuery settings
+    big_query_project_id = "data-pipeline"
+
+
 class prod(dev):
     pass
 

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -127,6 +127,15 @@ class dev():
     typesetter_digest_endpoint = 'https://example.org/job.api/updateDigest'
     typesetter_digest_api_key = ''
 
+    # journal preview
+    journal_preview_base_url = 'https://preview.example.org'
+
+    # Publication email settings
+    features_publication_recipient_email = []
+
+    # Email video article published settings
+    email_video_recipient_email = []
+
     # EJP S3 settings
     ejp_bucket = 'ejp'
 

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -203,6 +203,13 @@ class dev():
     SCOPUS_FTP_USERNAME = ""
     SCOPUS_FTP_PASSWORD = ""
     SCOPUS_FTP_CWD = ""
+    SCOPUS_EMAIL = ""
+
+    # Scopus SFTP settings
+    SCOPUS_SFTP_URI = ""
+    SCOPUS_SFTP_USERNAME = ""
+    SCOPUS_SFTP_PASSWORD = ""
+    SCOPUS_SFTP_CWD = ""
 
     # Web of Science WoS FTP settings
     WOS_FTP_URI = ""

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -112,10 +112,28 @@ class dev():
     # EJP S3 settings
     ejp_bucket = 'ejp'
 
+    # Crossref generation
+    elifecrossref_config_file = 'crossref.cfg'
+    elifecrossref_config_section = 'elife'
+
     # Crossref
     crossref_url = 'http://crossref.org/servlet/deposit'
     crossref_login_id = ''
     crossref_login_passwd = ''
+
+    # PubMed generation
+    elifepubmed_config_file = 'pubmed.cfg'
+    elifepubmed_config_section = 'elife'
+
+    # PoA generation
+    jatsgenerator_config_file = 'jatsgenerator.cfg'
+    jatsgenerator_config_section = 'elife'
+    packagepoa_config_file = 'packagepoa.cfg'
+    packagepoa_config_section = 'elife'
+
+    # Decision letter parser
+    letterparser_config_file = 'letterparser.cfg'
+    letterparser_config_section = 'elife'
 
     # PubMed FTP settings
     PUBMED_FTP_URI = ""

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -84,6 +84,10 @@ class dev():
     # POA packaging bucket
     poa_packaging_bucket = 'poa-packaging'
 
+    # Article subjects data
+    article_subjects_data_bucket = "bot/article_subjects_data"
+    article_subjects_data_file = "article_subjects.csv"
+ 
     # POA email settings
     ses_poa_sender_email = ""
     ses_poa_recipient_email = ""

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -36,7 +36,6 @@ class dev():
 
     s3_hostname = 's3.amazonaws.com'
     production_bucket = 'production'
-    eif_bucket = 'eif'
     expanded_bucket = 'expanded'
     ppp_cdn_bucket = 'ppp-cdn'
     archive_bucket = 'archive'

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -71,8 +71,6 @@ class dev():
 
     # Lens bucket settings
     lens_bucket = 'lens'
-    lens_distribution_id = ''
-    lens_domain_name = '.cloudfront.net'
 
     # Lens jpg bucket
     lens_jpg_bucket = "lens-jpg"

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -102,6 +102,31 @@ class dev():
     ses_poa_sender_email = ""
     ses_poa_recipient_email = ""
 
+    # Digest email settings
+    digest_config_file = 'digest.cfg'
+    digest_config_section = 'elife'
+    digest_sender_email = ""
+    # recipients of digest validation error emails
+    digest_validate_error_recipient_email = []
+    # recipients of digest docx email attachment
+    digest_docx_recipient_email = []
+    # recipients of post digest to endpoint emails and error emails
+    digest_jats_recipient_email = []
+    digest_jats_error_recipient_email = []
+    # recipients of digest medium post created emails
+    digest_medium_recipient_email = []
+    # old digest email settings below, keep until new code is deployed
+    digest_recipient_email = []
+    digest_error_recipient_email = []
+
+    # digest endpoint
+    digest_endpoint = 'https://example.org/digests/{digest_id}'
+    digest_auth_key = ""
+
+    # digest typesetter endpoint
+    typesetter_digest_endpoint = 'https://example.org/job.api/updateDigest'
+    typesetter_digest_api_key = ''
+
     # PMC email settings
     ses_pmc_sender_email = ""
     ses_pmc_recipient_email = ""

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -185,6 +185,7 @@ class dev():
     HEFCE_SFTP_USERNAME = ""
     HEFCE_SFTP_PASSWORD = ""
     HEFCE_SFTP_CWD = ""
+    HEFCE_EMAIL = ""
 
     # Cengage Archive FTP settings
     CENGAGE_FTP_URI = ""
@@ -216,6 +217,20 @@ class dev():
     WOS_FTP_USERNAME = ""
     WOS_FTP_PASSWORD = ""
     WOS_FTP_CWD = ""
+    WOS_EMAIL = ""
+
+    # CNPIEC FTP settings
+    CNPIEC_FTP_URI = ""
+    CNPIEC_FTP_USERNAME = ""
+    CNPIEC_FTP_PASSWORD = ""
+    CNPIEC_FTP_CWD = ""
+
+    # CNKI FTP settings
+    CNKI_FTP_URI = ""
+    CNKI_FTP_USERNAME = ""
+    CNKI_FTP_PASSWORD = ""
+    CNKI_FTP_CWD = ""
+    CNKI_EMAIL = ""
 
     # Templates S3 settings
     templates_bucket = 'bot'

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -41,13 +41,6 @@ class dev():
     archive_bucket = 'archive'
     xml_bucket = 'xml'
 
-    # REST endpoint for drupal node builder
-    # drupal_naf_endpoint = 'http://localhost:5000/nodes'
-    drupal_EIF_endpoint = 'http://drupalsite.example/api/article.json'
-    drupal_approve_endpoint = 'http://drupalsite.example/api/publish/'
-    drupal_update_user = ''
-    drupal_update_pass = ''
-
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://laxsite.example/api/v1/article/10.7554/eLife.{article_id}/version/'
     lax_update = 'http://laxsite.example/api/v1/import/article/'

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -127,10 +127,6 @@ class dev():
     typesetter_digest_endpoint = 'https://example.org/job.api/updateDigest'
     typesetter_digest_api_key = ''
 
-    # PMC email settings
-    ses_pmc_sender_email = ""
-    ses_pmc_recipient_email = ""
-
     # EJP S3 settings
     ejp_bucket = 'ejp'
 

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -43,10 +43,8 @@ class dev():
 
     # lax endpoint to retrieve information about published versions of articles
     lax_article_versions = 'http://laxsite.example/api/v1/article/10.7554/eLife.{article_id}/version/'
-    lax_update = 'http://laxsite.example/api/v1/import/article/'
-    lax_update_user = ''
-    lax_update_pass = ''
     verify_ssl = False
+    lax_auth_key = ''
 
     no_download_extensions = 'tif'
 


### PR DESCRIPTION
Matches with `elife-bot` PR https://github.com/elifesciences/elife-bot/pull/987 where `letterparser_config_file` and `letterparser_config_section` is added to the example settings file.

I noticed there were a bunch of other settings omitted from the example file in this project, and I added those to this first commit.

There are even more settings missing here, including the digest parser and digest API settings and possibly more (I didn't compare in great detail).

Do any reviewers think it is a good idea to compare all the values in `settings.py` to the https://github.com/elifesciences/elife-bot/blob/develop/settings-example.py file so these are more a one-to-one match?