### PR TITLE
docker_image pandoc version 2.9.1.1

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
@@ -8,6 +8,7 @@ video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
 [elife]
 doi_pattern: 10.7554/eLife.{manuscript:0>5}.{id}
 preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
+# docker_image populated by https://alfred.elifesciences.org/job/process/job/process-mirror-pandoc/
 docker_image: elifesciences/pandoc:2.9.1.1
 fig_filename_pattern: elife-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: elife-{manuscript:0>5}-{id_value}-video{num}

--- a/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-letterparser.cfg
@@ -1,13 +1,13 @@
 [DEFAULT]
 doi_pattern:
 preamble: 
-docker_image: pandoc/core:2.7
+docker_image: pandoc/core:2.9.1.1
 fig_filename_pattern: journalname-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
 
 [elife]
 doi_pattern: 10.7554/eLife.{manuscript:0>5}.{id}
 preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
-docker_image: elifesciences/pandoc:2.7
+docker_image: elifesciences/pandoc:2.9.1.1
 fig_filename_pattern: elife-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: elife-{manuscript:0>5}-{id_value}-video{num}


### PR DESCRIPTION
Re: issue https://github.com/elifesciences/issues/issues/5429

Blocked by Docker hub tag of `elifesciences/pandoc:2.9.1.1` existing first.

To be merged and deployed along with a matching `elife-bot` PR, which I will be preparing now.