### PR TITLE
replaced 'user' in cmd.* invocations to 'runas'

### DIFF
--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -41,7 +41,7 @@ elife-bot-virtualenv:
     cmd.run:
         - name: ./install.sh
         - cwd: /opt/elife-bot
-        - user: {{ pillar.elife.deploy_user.username }}
+        - runas: {{ pillar.elife.deploy_user.username }}
         - require:
             # Pillow depends on libjpeg + zlib that imagemagick pulls in
             - elife-bot-deps 
@@ -204,7 +204,7 @@ register-swf:
         {% else %}
         - name: echo "register.py cannot run locally as it requires AWS credentials"
         {% endif %}
-        - user: {{ pillar.elife.deploy_user.username }}
+        - runas: {{ pillar.elife.deploy_user.username }}
         - cwd: /opt/elife-bot
         - require:
             - cmd: app-done

--- a/salt/elife-bot/strip-coverletter.sls
+++ b/salt/elife-bot/strip-coverletter.sls
@@ -43,7 +43,7 @@ strip-coverletter-docker-image:
 
 strip-coverletter-docker-working:
     cmd.run:
-        - user: {{ pillar.elife.deploy_user.username }}
+        - runas: {{ pillar.elife.deploy_user.username }}
         - cwd: /opt/strip-coverletter
         - name: ./strip-coverletter-docker.sh /opt/strip-coverletter/dummy.pdf /tmp/dummy.pdf && rm /tmp/dummy.pdf
         - require:


### PR DESCRIPTION
fyi @gnott , the 'user' parameter of the `cmd.*` states were deprecated a while back and removed in 2018.3, the version of Salt we're upgrading to. Using `user` doesn't issue a warning so be careful going forwards