### PR TITLE
Swap PubMed FTP credentials for SFTP ones.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -162,11 +162,11 @@ class dev():
     letterparser_config_file = 'letterparser.cfg'
     letterparser_config_section = 'elife'
 
-    # PubMed FTP settings
-    PUBMED_FTP_URI = ""
-    PUBMED_FTP_USERNAME = ""
-    PUBMED_FTP_PASSWORD = ""
-    PUBMED_FTP_CWD = ""
+    # PubMed SFTP settings
+    PUBMED_SFTP_URI = ""
+    PUBMED_SFTP_USERNAME = ""
+    PUBMED_SFTP_PASSWORD = ""
+    PUBMED_SFTP_CWD = ""
 
     # PMC FTP settings
     PMC_FTP_URI = ""


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5648

Reflecting the recent changes to send PubMed deposits by SFTP, and no longer by FTP, here is the change to credentials in the `settings.py` file.