### PR TITLE
Crossmark settings changed in crossref.cfg

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -7,9 +7,10 @@ email_address:
 contrib_types: ["author", "on-behalf-of"]
 jats_abstract: false
 face_markup: false
-crossmark: true
+crossmark: false
 crossmark_policy:
-crossmark_domain:
+crossmark_domains: []
+crossmark_domain_exclusive: false
 batch_file_prefix: crossref-
 doi_pattern: 
 component_doi_pattern: 
@@ -29,7 +30,10 @@ text_mining_pdf_pattern:
 registrant: eLife
 depositor_name: eLife
 email_address: production@elifesciences.org
-crossmark: false
+crossmark: true
+crossmark_policy:
+crossmark_domains: [{"domain": "elifesciences.org", "filter": ""}]
+crossmark_domain_exclusive: false
 batch_file_prefix: elife-crossref-
 doi_pattern: https://elifesciences.org/articles/{manuscript}
 component_doi_pattern: https://elifesciences.org/articles/{manuscript}{prefix1}#{id}


### PR DESCRIPTION
Settings to support issue https://github.com/elifesciences/elife-crossref-feed/issues/145

There will be some new code introduced to the `elife-crossref-xml-generation` library soon which adds Crossmark data to Crossref deposits. The old settings in the `crossref.cfg` file were never used.

I tested how this updated file is still compatible with the currently deployed version of the `elifecrossref` library and all the unit tests pass, as was expected, which should make this PR safe to merge prior to the code being deployed.