### PR TITLE
In pubmed.cfg also populate the references data.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-pubmed.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-pubmed.cfg
@@ -6,7 +6,7 @@ pub_date_types: ["pub", "publication", "epub"]
 language: EN
 batch_file_prefix: pubmed-
 # default build parts when parsing article XML, omits the is_poa part which is eLife specific
-build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'keywords', 'license', 'pub_dates', 'related_articles', 'research_organisms', 'volume']
+build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'keywords', 'license', 'pub_dates', 'references', 'related_articles', 'research_organisms', 'volume']
 # tags to remove when cleaning the abstract from article XML
 remove_tags: ["xref", "ext-link"]
 author_contrib_types: ["author"]
@@ -20,6 +20,6 @@ abstract_label_types: []
 [elife]
 year_of_first_volume: 2012
 batch_file_prefix: elife-pubmed-
-build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'is_poa', 'keywords', 'license', 'pub_dates', 'related_articles', 'research_organisms', 'volume']
+build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'funding', 'history', 'is_poa', 'keywords', 'license', 'pub_dates', 'references', 'related_articles', 'research_organisms', 'volume']
 split_article_categories: True
 abstract_label_types: ["Editorial note:"]


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-pubmed-feed/issues/78

In the near future, we want to add the citations of type data, if they have an appropriate `<source>` tag value, to the PubMed dataset objects. In order to do this, we need to populate the `references` of an article when parsing the XML. 

This PR adds `'references'` to the list of article data it parses when populating Article objects.