### PR TITLE
Add clinical_trials_registries to crossref.cfg

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -25,6 +25,7 @@ pub_date_types: ["pub", "publication", "epub", "epub-ppub"]
 reference_distribution_opts:
 text_mining_xml_pattern: 
 text_mining_pdf_pattern:
+clinical_trials_registries: https://doi.org/10.18810/registries
 
 [elife]
 registrant: eLife


### PR DESCRIPTION
As part of developing issue https://github.com/elifesciences/elife-crossref-feed/issues/146, and after some thinking today, it is probably best to put the URL for the Crossref hosted clinical trials registries data into the `crossref.cfg` file, as I've done here. In this way, it is closely aligned with the library that will use the data.

It will eventually be invoked by the `elife-bot`, passing in this config value, and `elife-crossref-xml-generation` library will use it when appropriate.

I have a branch of code that will be ready to PR (hopefully) in a few days (https://github.com/elifesciences/elife-crossref-xml-generation/tree/clinical-trials) and I think this `crossref.cfg` value will remain here unless something really unexpected turns up.