### PR TITLE
eLife Crossref deposits, use jats_abstract true.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -31,6 +31,7 @@ clinical_trials_registries: https://doi.org/10.18810/registries
 registrant: eLife
 depositor_name: eLife
 email_address: production@elifesciences.org
+jats_abstract: true
 crossmark: true
 crossmark_policy:
 crossmark_domains: [{"domain": "elifesciences.org", "filter": ""}]


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5743

As part of structured abstracts support in the Crossref generation library, eLife will try sending full JATS abstracts instead of the simplified abstract type the library produces.