### PR TITLE
Remove group_author_contrib_types from pubmed.cfg

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-pubmed.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-pubmed.cfg
@@ -10,7 +10,6 @@ build_parts: ['abstract', 'basic', 'categories', 'contributors', 'datasets', 'fu
 # tags to remove when cleaning the abstract from article XML
 remove_tags: ["xref", "ext-link"]
 author_contrib_types: ["author"]
-group_author_contrib_types: ["author non-byline", "on-behalf-of"]
 history_date_types: ["received", "accepted"]
 split_article_categories: False
 publication_types: publication_types.yaml


### PR DESCRIPTION
Should be safe to merge ~now that~ after PR https://github.com/elifesciences/elife-bot/pull/1160 is merged, if we don't have to roll back anything due to errors.  Edit: I haven't merged the `elife-bot` PR yet, but I hope to do so today, if tests run successfully.