### PR TITLE
assertion_display_channel_types to crossref.cfg

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -26,6 +26,8 @@ reference_distribution_opts:
 text_mining_xml_pattern: 
 text_mining_pdf_pattern:
 clinical_trials_registries: https://doi.org/10.18810/registries
+# if the article has one of the following display_channel value then add crossmark custom_metadata assertion tags,case-insensitive matching
+assertion_display_channel_types: ["research article", "short report", "tools and resources", "research advance", "review article"]
 
 [elife]
 registrant: eLife


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6620
Re PR https://github.com/elifesciences/elife-crossref-xml-generation/pull/94

Adding the `assertion_display_channel_types` value to the `crossref.cfg` file will support the new code, and will not cause any backwards compatibiltiy issues.