### PR TITLE
Use master branch for elife-email-templates.

### DIFF
--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -119,8 +119,8 @@ elife-email-templates-repo:
     builder.git_latest:
         - name: git@github.com:elifesciences/elife-email-templates.git
         - identity: {{ pillar.elife.projects_builder.key or '' }}
-        - rev: {{ salt['elife.cfg']('project.revision', 'project.branch', 'master') }}
-        - branch: {{ salt['elife.branch']() }}
+        - rev: master
+        - branch: master
         - force_fetch: True
         - force_checkout: True
         - force_reset: True


### PR DESCRIPTION
Fix to PR https://github.com/elifesciences/elife-bot-formula/pull/70

On running the formula in a pipline, the branch or revision of the `elife-email-templates` repository may be incorrect, e.g.

```
07:51:14  [54.236.21.243] out: [ERROR   ] Fetch did not successfully retrieve rev 'cb5deab61572c4305973bbde99a74987c606c32d' from git@github.com:elifesciences/elife-email-templates.git: Command 'git rev-parse cb5deab61572c4305973bbde99a74987c606c32d^{commit}' failed: fatal: ambiguous argument 'cb5deab61572c4305973bbde99a74987c606c32d^{commit}': unknown revision or path not in the working tree.
07:51:14  [54.236.21.243] out: Use '--' to separate paths from revisions, like this:
07:51:14  [54.236.21.243] out: 'git <command> [<revision>...] -- [<file>...]'
```

For now, we can probably just use `master` all the time, until we reach a point where we want to specify a different branch for other environments.