### PR TITLE
Install ghostscript too.

### DIFF
--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -5,6 +5,7 @@ elife-bot-deps:
             - libxslt1-dev
             - lzma-dev # provides 'lz' for compiling lxml
             - imagemagick
+            - ghostscript
             - libmagickwand-dev
         - require:
             - pkg: python-dev


### PR DESCRIPTION
It makes sense the next exception `wand.exceptions.WandRuntimeError: ...` did not appear until the `policy.xml` file was configured. After reading the PDF file, I think `ghostscript` is also required here too, as it was in the `elife-libraries-formula`.