### PR TITLE
Add era_queue_worker to the multiservice list.

### DIFF
--- a/salt/pillar/elife-bot.sls
+++ b/salt/pillar/elife-bot.sls
@@ -67,3 +67,7 @@ elife:
                 service_template: elife-bot-lax_response_adapter-service
                 num_processes: 2
 
+            era_queue_worker:
+                service_template: elife-bot-era_queue_worker-service
+                num_processes: 2
+


### PR DESCRIPTION
Re `elife-bot` PR https://github.com/elifesciences/elife-bot/pull/1253  adds `era_queue_worker.py`, and this is a part of enabling it as a servicie on the instance.