### PR TITLE
Add accepted_submission_queue to settings.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -307,6 +307,7 @@ class dev():
     # Accepted submission workflow
     accepted_submission_sender_email = "sender@example.org"
     accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]
+    accepted_submission_queue = ""
 
 
 class prod(dev):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6436

Add the `accepted_submission_queue` property to the settings.py file, which will be used soon, if it is a non-blank value.