### PR TITLE
Set Crossref schema to 4.4.2 in crossref.cfg

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-crossref_schema_version: 4.4.1
+crossref_schema_version: 4.4.2
 generator: elife-crossref-xml-generation
 registrant: 
 depositor_name: 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6569

It should be safe to start generating Crossref deposits to use their version `4.4.2` schema, which is looking to be compatible with the previously used `4.4.1` for eLife's purposes.