### PR TITLE
In Crossref deposits use schema version 5.3.1

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-crossref_schema_version: 4.4.2
+crossref_schema_version: 5.3.1
 generator: elife-crossref-xml-generation
 registrant: 
 depositor_name: 


### PR DESCRIPTION
To be accompanied with an `elife-bot` PR which will use `elifecrossref==0.10.0`, it will only generate Crossref deposits that are compatible with Crossref schema version `5.3.1`.