### PR TITLE
Add accepted_submission_output_bucket to settings.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -305,6 +305,7 @@ class dev():
     era_incoming_queue = "dev-era-incoming-queue"
 
     # Accepted submission workflow
+    accepted_submission_output_bucket = "dev-elife-bot-accepted-submission-cleaning-output"
     accepted_submission_sender_email = "sender@example.org"
     accepted_submission_validate_error_recipient_email = ["e@example.org", "life@example.org"]
     accepted_submission_queue = ""


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7026

Soon to be added a new `elife-bot` activity which will upload accepted submission zip files to an output bucket specified by this new settings value.