### PR TITLE
First version of downstreamRecipients.yaml file

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -1,0 +1,77 @@
+# Details for workflows which send article data to downstream recipients
+# Includes workflows which rely on S3 bucket outbox folders
+# Key names starting with "settings_" are the variable name in settings.py holding the value
+
+# non-FTPArticle workflows
+crossref:
+  activity_name: DepositCrossref
+  s3_bucket_folder: crossref
+
+crossref:
+  activity_name: DepositCrossrefPeerReview
+  s3_bucket_folder: crossref_peer_review
+
+crossref:
+  activity_name: DepositCrossrefPendingPublication
+  s3_bucket_folder: crossref_pending_publication
+
+PMC:
+  activity_name: PMCDeposit
+  s3_bucket_folder: pmc
+
+Pubmed:
+  activity_name: PubmedArticleDeposit
+  s3_bucket_folder: pubmed
+
+
+# FTPArticle workflows
+Cengage:
+  activity_name: FTPArticle
+  s3_bucket_folder: cengage
+  settings_friendly_email_recipients: CENGAGE_EMAIL
+
+CLOCKSS:
+  activity_name: FTPArticle
+  s3_bucket_folder: clockss
+  settings_friendly_email_recipients: CLOCKSS_EMAIL
+
+CNKI:
+  activity_name: FTPArticle
+  s3_bucket_folder: cnki
+  settings_friendly_email_recipients: CNKI_EMAIL
+
+CNPIEC:
+  activity_name: FTPArticle
+  s3_bucket_folder: cnpiec
+  settings_friendly_email_recipients: CNPIEC_EMAIL
+
+GoOA:
+  activity_name: FTPArticle
+  s3_bucket_folder: gooa
+  settings_friendly_email_recipients: GOOA_EMAIL
+
+HEFCE:
+  activity_name: FTPArticle
+  s3_bucket_folder: pub_router
+  settings_friendly_email_recipients: HEFCE_EMAIL
+
+OASwitchboard:
+  activity_name: FTPArticle
+  s3_bucket_folder: oaswitchboard
+  settings_friendly_email_recipients: OASWITCHBOARD_EMAIL
+
+OVID:
+  activity_name: FTPArticle
+  s3_bucket_folder: ovid
+  settings_friendly_email_recipients: OVID_EMAIL
+
+WoS:
+  activity_name: FTPArticle
+  s3_bucket_folder: wos
+  settings_friendly_email_recipients: WOS_EMAIL
+
+Zendy:
+  activity_name: FTPArticle
+  s3_bucket_folder: zendy
+  settings_friendly_email_recipients: ZENDY_EMAIL
+

--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -7,11 +7,11 @@ crossref:
   activity_name: DepositCrossref
   s3_bucket_folder: crossref
 
-crossref:
+crossref_peer_review:
   activity_name: DepositCrossrefPeerReview
   s3_bucket_folder: crossref_peer_review
 
-crossref:
+crossref_pending_publication:
   activity_name: DepositCrossrefPendingPublication
   s3_bucket_folder: crossref_pending_publication
 

--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -133,6 +133,14 @@ elife-email-templates-repo:
         - force_reset: True
         - target: /opt/elife-email-templates
 
+elife-bot-downstreamRecipients-cfg:
+    file.managed:
+        - user: {{ pillar.elife.deploy_user.username }}
+        - name: /opt/elife-bot/downstreamRecipients.yaml
+        - source: salt://elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+        - require:
+            - elife-bot-repo
+
 #
 # clean up the temporary files that accumulate
 #


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7652

Hopefully this is configured correctly to add a new `.yaml` file to the project, unless the salt value `elife-bot-downstreamRecipients-cfg` should not be camel case, dunno!