### PR TITLE
Downstream yaml

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -3,15 +3,15 @@
 # Key names starting with "settings_" are the variable name in settings.py holding the value
 
 # non-FTPArticle workflows
-crossref:
+DepositCrossref:
   activity_name: DepositCrossref
   s3_bucket_folder: crossref
 
-crossref_peer_review:
+DepositCrossrefPeerReview:
   activity_name: DepositCrossrefPeerReview
   s3_bucket_folder: crossref_peer_review
 
-crossref_pending_publication:
+DepositCrossrefPendingPublication:
   activity_name: DepositCrossrefPendingPublication
   s3_bucket_folder: crossref_pending_publication
 

--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -19,6 +19,10 @@ PMC:
   activity_name: PMCDeposit
   s3_bucket_folder: pmc
 
+publication_email:
+  activity_name: PublicationEmail
+  s3_bucket_folder: publication_email
+
 Pubmed:
   activity_name: PubmedArticleDeposit
   s3_bucket_folder: pubmed

--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -19,7 +19,7 @@ PMC:
   activity_name: PMCDeposit
   s3_bucket_folder: pmc
 
-publication_email:
+PublicationEmail:
   activity_name: PublicationEmail
   s3_bucket_folder: publication_email
 


### PR DESCRIPTION
Revisions to earlier PR https://github.com/elifesciences/elife-bot-formula/pull/93 

The outbox details for `publication_email` was missed, and change the workflow name keys for the Crossref deposit ones.