### PR TITLE
adds temporary state to move docker from /ext/docker to /bot-tmp/docker

### DIFF
--- a/salt/elife-bot/strip-coverletter.sls
+++ b/salt/elife-bot/strip-coverletter.sls
@@ -46,6 +46,7 @@ strip-coverletter-docker-working:
         - cwd: /opt/strip-coverletter
         - name: ./strip-coverletter-docker.sh /opt/strip-coverletter/dummy.pdf /tmp/dummy.pdf && rm /tmp/dummy.pdf
         - require:
+            - elife-bot-migrate-docker-to-bot-tmp
             - strip-coverletter-docker-image
             - strip-coverletter-writeable-work-dir
             - strip-coverletter-docker-writable-dir


### PR DESCRIPTION
will need to be coordinated with these changes https://github.com/elifesciences/builder-base-formula/pull/381 as the new state depends on the symlink in `docker-native.docker-folder-linking` being updated to point to /bot-tmp/docker

fyi @gnott 