### PR TITLE
strip-coverletter is no longer built on highstate.

### DIFF
--- a/salt/elife-bot/strip-coverletter.sls
+++ b/salt/elife-bot/strip-coverletter.sls
@@ -34,9 +34,9 @@ strip-coverletter-writeable-work-dir:
             - test -d /bot-tmp
 
 strip-coverletter-docker-image:
-    cmd.run:
-        - cwd: /opt/strip-coverletter
-        - name: ./build-image.sh
+    docker_image.present:
+        - name: elifesciences/strip-coverletter
+        - tag: latest
         - require:
             - docker-ready
 


### PR DESCRIPTION
instead it's pulled from dockerhub