### PR TITLE
DepositCrossrefMinimal added to yaml file.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -7,6 +7,10 @@ DepositCrossref:
   activity_name: DepositCrossref
   s3_bucket_folder: crossref
 
+DepositCrossrefMinimal:
+  activity_name: DepositCrossrefMinimal
+  s3_bucket_folder: crossref_minimal
+
 DepositCrossrefPeerReview:
   activity_name: DepositCrossrefPeerReview
   s3_bucket_folder: crossref_peer_review


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7550

Soon to be added a workflow activity to deposit a "minimal" Crossref deposit, to reset related article data, prior to depositing the full data to Crossref again. It will use a separate S3 bucket folder to hold outbox XML files.