### PR TITLE
Add assessment_terms.yaml file

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-assessment_terms.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-assessment_terms.yaml
@@ -1,0 +1,68 @@
+Compelling:
+  group:
+    evidence-strength
+  terms:
+    - compelling
+
+Convincing:
+  group:
+    evidence-strength
+  terms:
+    - convincing
+    - convincingly
+
+Exceptional:
+  group:
+    evidence-strength
+  terms:
+    - exceptional
+
+Fundamental:
+  group:
+    claim-importance
+  terms:
+    - fundamental
+
+Important:
+  group:
+    claim-importance
+  terms:
+    - important
+
+Inadequate:
+  group:
+    evidence-strength
+  terms:
+    - inadequate
+    - inadequately
+
+Incomplete:
+  group:
+    evidence-strength
+  terms:
+    - incomplete
+    - incompletely
+
+Landmark:
+  group:
+    claim-importance
+  terms:
+    - landmark
+
+Solid:
+  group:
+    evidence-strength
+  terms:
+    - solid
+
+Useful:
+  group:
+    claim-importance
+  terms:
+    - useful
+
+Valuable:
+  group:
+    claim-importance
+  terms:
+    - valuable

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -336,6 +336,8 @@ class dev():
     docmap_url_pattern = "https://example.org/path/get-by-id?preprint_doi={doi}"
     docmap_account_id = "https://sciety.org/groups/elife"
 
+    assessment_terms_yaml = "assessment_terms.yaml"
+
 
 class prod(dev):
     pass

--- a/salt/elife-bot/init.sls
+++ b/salt/elife-bot/init.sls
@@ -143,6 +143,14 @@ elife-bot-downstreamRecipients-cfg:
         - require:
             - elife-bot-repo
 
+elife-bot-assessment_terms-cfg:
+    file.managed:
+        - user: {{ pillar.elife.deploy_user.username }}
+        - name: /opt/elife-bot/assessment_terms.yaml
+        - source: salt://elife-bot/config/opt-elife-bot-assessment_terms.yaml
+        - require:
+            - elife-bot-repo
+
 #
 # clean up the temporary files that accumulate
 #


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8176

Adding another YAML file to the instance. Only if you have time to take a peek at the salt portion @lsh-0, no worries if not.