### PR TITLE
jatsgenerator.cfg elocation_id, elife_preprint

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-jatsgenerator.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-jatsgenerator.cfg
@@ -6,6 +6,7 @@ history_date_types: ["received", "accepted"]
 journal_title: 
 journal_issn:
 publisher_name:
+elocation_id_pattern: e{manuscript:0>5}
 xml_filename_pattern: {manuscript}.xml
 target_output_dir: tmp
 
@@ -16,3 +17,13 @@ journal_title: eLife
 journal_issn: 2050-084X
 publisher_name: eLife Sciences Publications, Ltd
 xml_filename_pattern: elife_poa_e{manuscript:0>5}.xml
+
+[elife_preprint]
+contrib_types: ["author"]
+journal_id_publisher-id: eLife
+journal_id_nlm-ta: elife
+journal_title: eLife
+journal_issn: 2050-084X
+publisher_name: eLife Sciences Publications, Ltd
+elocation_id_pattern: RP{manuscript:0>5}
+xml_filename_pattern: elife-preprint-{manuscript:0>5}.xml


### PR DESCRIPTION
Updates to the `jatsgenerator.cfg` file,

`elocation_id_pattern` rule will result in different values generated by the next version of `jatsgenerator` library
`elife_preprint` section will be used to generate preprint XML snippets

These changes are backwards compatible with previous versions of `jatsgenerator`, and this PR can be merged immediately.

Re issue https://github.com/elifesciences/issues/issues/8068 for generating preprint XML.