### PR TITLE
Add elife_preprint section to crossref.cfg

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -51,3 +51,12 @@ access_indicators_applies_to: ["vor", "am", "tdm"]
 reference_distribution_opts: any
 text_mining_xml_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.xml
 text_mining_pdf_pattern: https://cdn.elifesciences.org/articles/{manuscript}/elife-{manuscript}{version}.pdf
+
+[elife_preprint]
+registrant: eLife
+depositor_name: eLife
+email_address: production@elifesciences.org
+batch_file_prefix: elife-crossref-preprint-
+doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}
+peer_review_doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/reviews#{id}
+elocation_id: true


### PR DESCRIPTION
Accompanies the latest version of `elifecrossref` library, will allow the `elife-bot` workflows to generate DOI deposits for reviewed preprint XML using the `elife_preprint` section of the config file.

Re issue https://github.com/elifesciences/issues/issues/7717

