### PR TITLE
DepositCrossrefPostedContent to downstream YAML.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -19,6 +19,10 @@ DepositCrossrefPendingPublication:
   activity_name: DepositCrossrefPendingPublication
   s3_bucket_folder: crossref_pending_publication
 
+DepositCrossrefPostedContent:
+  activity_name: DepositCrossrefPostedContent
+  s3_bucket_folder: crossref_posted_content
+
 PMC:
   activity_name: PMCDeposit
   s3_bucket_folder: pmc


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7717

Some `elife-bot` code coming shortly will use this S3 outbox folder for depositing `posted_content` to Crossref.