### PR TITLE
crossref.cfg preprint peer review DOI pattern.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -60,6 +60,6 @@ depositor_name: eLife
 email_address: production@elifesciences.org
 batch_file_prefix: elife-crossref-preprint-
 doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}
-peer_review_doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/reviews#{id}
+peer_review_doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/reviews
 elocation_id: true
 iparadigms_preprint_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/pdf


### PR DESCRIPTION
The `@id` is not required here for now.