### PR TITLE
In crossref.cfg add pub_date_types for elife_preprint

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -62,4 +62,5 @@ batch_file_prefix: elife-crossref-preprint-
 doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}
 peer_review_doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/reviews
 elocation_id: true
+pub_date_types: ["posted_date"]
 iparadigms_preprint_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/pdf


### PR DESCRIPTION
Crossref peer review deposits for preprints are missing a `review_date`. Adding `posted_date` type should help to get the date from the XML file.