### PR TITLE
crossref.cfg modify elife_preprint, add elife_preprint_version

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-crossref.cfg
+++ b/salt/elife-bot/config/opt-elife-bot-crossref.cfg
@@ -60,7 +60,18 @@ depositor_name: eLife
 email_address: production@elifesciences.org
 batch_file_prefix: elife-crossref-preprint-
 doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}
-peer_review_doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/reviews
+peer_review_doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}{url_version}/reviews
 elocation_id: true
 pub_date_types: ["posted_date"]
-iparadigms_preprint_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}/pdf
+iparadigms_preprint_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}{url_version}/pdf
+
+[elife_preprint_version]
+registrant: eLife
+depositor_name: eLife
+email_address: production@elifesciences.org
+batch_file_prefix: elife-crossref-preprint-version-
+doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}{url_version}
+peer_review_doi_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}{url_version}/reviews
+elocation_id: true
+pub_date_types: ["posted_date"]
+iparadigms_preprint_pattern: https://elifesciences.org/reviewed-preprints/{manuscript}{url_version}/pdf


### PR DESCRIPTION
Changes to `crossref.cfg` for more precise URLs in preprint Crossref deposits.

Re issue https://github.com/elifesciences/issues/issues/8549