### PR TITLE
Add preprint PublicationEmail to downstream YAML rules.

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -48,6 +48,14 @@ PublicationEmail:
     - poa
     - vor
 
+PreprintPublicationEmail:
+  activity_name: PublicationEmail
+  s3_bucket_folder: publication_email
+  schedule_downstream: true
+  schedule_first_version_only: false
+  schedule_article_types:
+    - preprint
+
 Pubmed:
   activity_name: PubmedArticleDeposit
   s3_bucket_folder: pubmed


### PR DESCRIPTION
For a preprint article, queue for `PublicationEmail` sending, every version of them.

Re issue https://github.com/elifesciences/issues/issues/8587