### PR TITLE
Docmaps downstream config

### DIFF
--- a/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
+++ b/salt/elife-bot/config/opt-elife-bot-downstreamRecipients.yaml
@@ -27,6 +27,10 @@ FindNewPreprints:
   activity_name: FindNewPreprints
   s3_bucket_folder: preprint
 
+FindNewDocmaps:
+  activity_name: FindNewDocmaps
+  s3_bucket_folder: docmaps
+
 PMC:
   activity_name: PMCDeposit
   s3_bucket_folder: pmc

--- a/salt/elife-bot/config/opt-elife-bot-settings.py
+++ b/salt/elife-bot/config/opt-elife-bot-settings.py
@@ -337,8 +337,23 @@ class dev():
 
     docmap_url_pattern = "https://example.org/path/get-by-manuscript-id?manuscript_id={article_id}"
     docmap_account_id = "https://sciety.org/groups/elife"
+    docmap_index_url = "https://example.org/path/index"
 
     assessment_terms_yaml = "assessment_terms.yaml"
+
+    # Mathpix settings
+    mathpix_endpoint = ""
+    mathpix_app_id = "elife-bot"
+    mathpix_app_key = ""
+
+    # EPP settings
+    epp_data_bucket = "epp_bucket"
+
+    # Striking images bucket
+    striking_images_bucket = "striking_images_bucket"
+
+    # user-agent for using in requests
+    user_agent = "user_agent/version (https://example.org)"
 
 
 class prod(dev):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8772

Primarily to add `FindNewDocmaps` configuration to the downstream recipients YAML file.

The example `settings.py` can be updated too to include the `docmap_index_url` value. There were many other values missing as compared to the settings currently in use and added those too.